### PR TITLE
Add blog detail page

### DIFF
--- a/components/Post.jsx
+++ b/components/Post.jsx
@@ -1,9 +1,13 @@
+import Link from 'next/link';
+
 const Post = ({ post }) => {
   return (
     <div>
       <span>{post.id}</span>
       {' : '}
-      <span className='cursor-pointer text-blue-500 border-b border-blue-500 hover:bg-gray-200'>{post.title}</span>
+      <Link href={`/posts/${post.id}`} passHref>
+        <span className='cursor-pointer text-blue-500 border-b border-blue-500 hover:bg-gray-200'>{post.title}</span>
+      </Link>
     </div>
   );
 };

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -6,3 +6,25 @@ export async function getAllPostsData() {
   const posts = await res.json();
   return posts;
 }
+
+export async function getAllPostIds() {
+  const res = await fetch(new URL(apiUrl));
+  const posts = await res.json();
+
+  return posts.map((post) => {
+    return {
+      params: {
+        id: String(post.id),
+      },
+    };
+  });
+} 
+
+export async function getPostData(id) {
+  const res = await fetch(new URL(`${apiUrl}/${id}/`));
+  const post = await res.json();
+
+  return {
+    post,
+  };
+}

--- a/pages/posts/[id].jsx
+++ b/pages/posts/[id].jsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import Layout from 'components/Layout';
+import { getAllPostIds, getPostData } from 'lib/posts';
+
+export default function Post({ post }) {
+  if (!post) {
+    return <div>Loading...</div>;
+  } else {
+    return (
+      <Layout title={post.title}>
+        <p className='m-4'>
+          {'ID : '}
+          {post.id}
+        </p>
+        <p className='mb-8 text-xl font-bold'>{post.title}</p>
+        <p className='px-10'>{post.body}</p>
+        <Link href='/blog-page' passHref>
+          <div className='flex cursor-pointer mt-12'>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              className='h-6 w-6 mr-3'
+              fill='none'
+              viewBox='0 0 24 24'
+              stroke='currentColor'
+            >
+              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M11 19l-7-7 7-7m8 14l-7-7 7-7' />
+            </svg>
+            <span>Back to Blog List Page</span>
+          </div>
+        </Link>
+      </Layout>
+    );
+  }
+}
+
+export async function getStaticPaths() {
+  const paths = await getAllPostIds();
+
+  return {
+    paths,
+    fallback: false, // 返されないパスは全て404となる(例えばid:101など)
+  };
+}
+
+export async function getStaticProps({ params }) {
+  const { post: post } = await getPostData(params.id);
+  return {
+    props: {
+      post,
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -87,6 +87,6 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
     "lib": ["dom", "dom.iterable", "esnext"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/index.tsx", "components/Layout.jsx", "pages/blog-page.jsx", "components/Post.jsx", "lib/posts.js"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/index.tsx", "components/Layout.jsx", "pages/blog-page.jsx", "components/Post.jsx", "lib/posts.js", "pages/posts/[id].jsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 概要
ブログ詳細ページの追加

## 実装内容
- 詳細ページの作成( pages/posts/[id].jsx ) 
  - JSX
  - pathとprops処理(getStaticPaths, getStaticProps)
- ブログIDの取得処理の追加( lib/posts.js )
- ブログ一覧ページから詳細ページへのリンク連携 ( components/Post.jsx )